### PR TITLE
Add onScroll prop

### DIFF
--- a/src/responsive-grid/types.ts
+++ b/src/responsive-grid/types.ts
@@ -1,6 +1,11 @@
 import type React from 'react';
 import type { ReactNode } from 'react';
-import type { StyleProp, ViewStyle } from 'react-native';
+import type {
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 
 interface RenderItemProps {
   item: any;
@@ -48,6 +53,9 @@ export interface ResponsiveGridProps {
 
   /** Defines the base unit height for items within the grid. If not provided, it's calculated based on container width and maxItemsPerColumn. */
   itemUnitHeight?: number;
+
+  /** Callback function triggered when the scroll view is scrolled. */
+  onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
 
   /** Callback function triggered when the scroll reaches near the end of the scrollable grid. */
   onEndReached?: () => void;


### PR DESCRIPTION
Hi there,

I added a prop exposing the onScroll handler for the scroll view. This is useful for disappearing page headers that scroll along with the page. Why not a header component? In my case I'm adjusting the header opacity as it scrolls.

I also refactored the scrollEventThrottle so the onScroll prop is unthrottled, this is necessary for smooth animations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an external scroll event handler in the ResponsiveGrid component, allowing custom actions when the grid is scrolled.

- **Refactor**
  - Improved scroll event handling with internal throttling for smoother performance and more efficient virtualization updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->