### PR TITLE
memoized grid Item

### DIFF
--- a/src/flex-grid/index.tsx
+++ b/src/flex-grid/index.tsx
@@ -9,6 +9,32 @@ import { calcFlexGrid } from './calc-flex-grid';
 import useThrottle from '../hooks/use-throttle';
 import { renderPropComponent } from '../libs/render-prop-component';
 
+// Memoized grid item component to prevent unnecessary re-renders
+const MemoizedGridItem = React.memo<{
+  item: FlexGridTile;
+  index: number;
+  itemSizeUnit: number;
+  itemContainerStyle: any;
+  renderItem: (props: { item: FlexGridTile; index: number }) => React.ReactElement;
+  keyExtractor: (item: FlexGridTile, index: number) => string;
+}>(({ item, index, itemSizeUnit, itemContainerStyle, renderItem, keyExtractor }) => (
+  <View
+    key={keyExtractor(item, index)}
+    style={[
+      {
+        position: 'absolute',
+        top: item.top,
+        left: item.left,
+        width: (item.widthRatio || 1) * itemSizeUnit,
+        height: (item.heightRatio || 1) * itemSizeUnit,
+      },
+      itemContainerStyle,
+    ]}
+  >
+    {renderItem({ item, index })}
+  </View>
+));
+
 export const FlexGrid: React.FC<FlexGridProps> = ({
   data = [],
   virtualization = true,
@@ -201,21 +227,15 @@ export const FlexGrid: React.FC<FlexGridProps> = ({
             }}
           >
             {renderedList.map((item, index) => (
-              <View
+              <MemoizedGridItem
                 key={keyExtractor(item, index)}
-                style={[
-                  {
-                    position: 'absolute',
-                    top: item.top,
-                    left: item.left,
-                    width: (item.widthRatio || 1) * itemSizeUnit,
-                    height: (item.heightRatio || 1) * itemSizeUnit,
-                  },
-                  itemContainerStyle,
-                ]}
-              >
-                {renderItem({ item, index })}
-              </View>
+                item={item}
+                index={index}
+                itemSizeUnit={itemSizeUnit}
+                itemContainerStyle={itemContainerStyle}
+                renderItem={renderItem}
+                keyExtractor={keyExtractor}
+              />
             ))}
           </View>
 

--- a/src/responsive-grid/index.tsx
+++ b/src/responsive-grid/index.tsx
@@ -14,6 +14,23 @@ import { calcResponsiveGrid } from './calc-responsive-grid';
 import useThrottle from '../hooks/use-throttle';
 import { renderPropComponent } from '../libs/render-prop-component';
 
+// Memoized grid item component to prevent unnecessary re-renders
+const MemoizedGridItem = React.memo<{
+  item: TileItem;
+  index: number;
+  itemContainerStyle: any;
+  renderItem: (props: { item: TileItem; index: number }) => React.ReactElement;
+  keyExtractor: (item: TileItem, index: number) => string;
+  getItemPositionStyle: (item: TileItem) => any;
+}>(({ item, index, itemContainerStyle, renderItem, keyExtractor, getItemPositionStyle }) => (
+  <View
+    key={keyExtractor(item, index)}
+    style={[getItemPositionStyle(item), itemContainerStyle]}
+  >
+    {renderItem({ item, index })}
+  </View>
+));
+
 export const ResponsiveGrid: React.FC<ResponsiveGridProps> = ({
   data = [],
   maxItemsPerColumn = 3,
@@ -256,12 +273,15 @@ export const ResponsiveGrid: React.FC<ResponsiveGridProps> = ({
           }}
         >
           {renderedItems.map((item, index) => (
-            <View
+            <MemoizedGridItem
               key={keyExtractor(item, index)}
-              style={[getItemPositionStyle(item), itemContainerStyle]}
-            >
-              {renderItem({ item, index })}
-            </View>
+              item={item}
+              index={index}
+              itemContainerStyle={itemContainerStyle}
+              renderItem={renderItem}
+              keyExtractor={keyExtractor}
+              getItemPositionStyle={getItemPositionStyle}
+            />
           ))}
         </View>
 


### PR DESCRIPTION
Memoize GridItem Component for Performance Optimization

This change wraps the GridItem component in React.memo to prevent unnecessary re-renders and improve rendering performance. The component is now only re-rendered when its props change, optimizing the grid's performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Flex Grid and Responsive Grid rendering with memoized item wrappers to reduce unnecessary re-renders.
  * Improves scrolling smoothness and responsiveness, especially with large grids.
  * No changes to the public API or visual behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->