### PR TITLE
memoize extractPadding function

### DIFF
--- a/src/responsive-grid/index.tsx
+++ b/src/responsive-grid/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 /* eslint-disable react-native/no-inline-styles */
 
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { ScrollView, View, StyleSheet } from 'react-native';
 import type {
   StyleProp,
@@ -81,7 +81,7 @@ export const ResponsiveGrid: React.FC<ResponsiveGridProps> = ({
     gridViewHeight + headerComponentHeight + footerComponentHeight;
 
   // Extract padding from style object
-  const extractPadding = (styleObj: StyleProp<ViewStyle>) => {
+  const extractPadding = useCallback((styleObj: StyleProp<ViewStyle>) => {
     if (!styleObj) return { horizontal: 0, vertical: 0 };
 
     const flatStyle = StyleSheet.flatten(styleObj);
@@ -110,7 +110,7 @@ export const ResponsiveGrid: React.FC<ResponsiveGridProps> = ({
     }
 
     return { horizontal, vertical };
-  };
+  }, []);
 
   // Update padding values when style changes when component style is changed
   useEffect(() => {
@@ -123,7 +123,7 @@ export const ResponsiveGrid: React.FC<ResponsiveGridProps> = ({
     ) {
       setComponentPadding(newPadding);
     }
-  }, [style, componentPadding.horizontal, componentPadding.vertical]);
+  }, [style, componentPadding.horizontal, componentPadding.vertical, extractPadding]);
 
   const updateVisibleItems = () => {
     if (!virtualization) return;


### PR DESCRIPTION
Memoizes the extractPadding function in ResponsiveGrid using useCallback to prevents unnecessary function recreations on every render.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal computation in the responsive grid to reduce unnecessary recalculations.
  * Updated effect dependencies to align with memoized logic for more predictable renders.
  * No changes to the public API or component props; functionality remains the same.
  * Users may notice minor performance improvements in grid rendering under frequent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->