### PR TITLE
Add removeClippedSubviews option to ResponsiveGrid

### DIFF
--- a/src/responsive-grid/index.tsx
+++ b/src/responsive-grid/index.tsx
@@ -34,6 +34,7 @@ export const ResponsiveGrid: React.FC<ResponsiveGridProps> = ({
   HeaderComponent = null,
   FooterComponent = null,
   direction = 'ltr',
+  removeClippedSubviews = true,
 }) => {
   const [visibleItems, setVisibleItems] = useState<TileItem[]>([]);
 
@@ -239,6 +240,7 @@ export const ResponsiveGrid: React.FC<ResponsiveGridProps> = ({
           width: '100%',
         }}
         showsVerticalScrollIndicator={showScrollIndicator}
+        removeClippedSubviews={removeClippedSubviews}
       >
         {/* Render HeaderComponent if provided */}
         <View

--- a/src/responsive-grid/types.ts
+++ b/src/responsive-grid/types.ts
@@ -85,6 +85,13 @@ export interface ResponsiveGridProps {
    * @default ltr
    */
   direction?: 'rtl' | 'ltr';
+
+  /**
+   * When true, off-screen child views (whose overflow value is hidden) are automatically removed from the native view hierarchy.
+   * This can improve performance for long lists, especially on Android when rendering remote images.
+   * @default true
+   */
+  removeClippedSubviews?: boolean;
 }
 
 export interface TileItem {


### PR DESCRIPTION
# Add removeClippedSubviews prop to ResponsiveGrid for Android performance

## Problem
ResponsiveGrid scrolling becomes laggy on Android 15 when rendering lists with remote image URIs according to this issue reported here https://github.com/iNerdStack/react-native-flexible-grid/issues/77

## Changes
- Added `removeClippedSubviews?: boolean` to ResponsiveGridProps
- Set default to `true` for better performance out of the box
- Passed prop to ScrollView component

## Impact
- Fixes laggy scrolling on Android with remote images
- Improves memory management for long lists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - ResponsiveGrid adds a new removeClippedSubviews prop (default: true) to automatically remove off-screen child views, improving scroll performance for long lists (notably on Android). You can disable it if needed.
  - No other rendering or layout behavior changed; headers, footers, and virtualization are unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->